### PR TITLE
Ac2 gantt 131 delete bug deletion

### DIFF
--- a/src/gantchart.ts
+++ b/src/gantchart.ts
@@ -77,7 +77,8 @@ export default class GanttChart {
             id: 'overall-div'
         });
         const addButtonWrapper = createElementFromObject('div', {
-            class: "add-tasks"
+            class: "add-tasks",
+            'id': 'add-tasks-div'
         })
 
         const svgInsideAddButton = this.createSvgButton();
@@ -299,7 +300,7 @@ export default class GanttChart {
                 event.preventDefault();
                 this.startDrag(event, rect, progressRect, task, tasks);
             });
-         
+
             addEventListenerDynamic(text, 'mousedown', (event) => {
                 event.preventDefault();
                 this.startDrag(event, rect, progressRect, task, tasks);
@@ -545,12 +546,12 @@ export default class GanttChart {
     }
 
     updateAddButton(tasks: ITask[]) {
-        const headerRow = document.getElementById('header-row');
+        const addButtonDiv = document.getElementById('add-tasks-div');
         const oldButton = document.getElementById('add-button');
-        headerRow.removeChild(oldButton);
+        addButtonDiv.removeChild(oldButton);
 
         const newButton = this.createButton(tasks);
-        headerRow.appendChild(newButton);
+        addButtonDiv.appendChild(newButton);
     }
 
     drawDependencyLine(svg: SVGElement, tasks: ITask[]) {

--- a/src/gantchart.ts
+++ b/src/gantchart.ts
@@ -37,6 +37,7 @@ export default class GanttChart {
     createButton(tasks: ITask[]) {
         const button = document.createElement('button');
         button.setAttribute('class', 'top-place add-button');
+        button.setAttribute('id', 'add-button');
         button.textContent = 'Add Task'; // Set the button text
         button.addEventListener('click', () => {
             openAddModal(tasks);
@@ -56,6 +57,7 @@ export default class GanttChart {
         // Create a button element
         const headerRow=createElementFromObject('div',{
             class:'row chart-header',
+            id:'header-row'
         });
         const button = this.createButton(tasks);
         let svg = chartContainer.querySelector('svg');
@@ -430,6 +432,7 @@ export default class GanttChart {
     }
 
     updateGanttChartContent(svg: SVGSVGElement, tasks: ITask[]) {
+        this.updateAddButton(tasks);
         const chartContainer = document.getElementById('chart');
         //clear the existing date div
         let DateDiv = document.getElementById('div-date');
@@ -451,6 +454,15 @@ export default class GanttChart {
         chartContainer.insertBefore(DateDiv, svg);
         this.createTaskBars(svg, tasks, this.dateInfo);
         this.drawDependencyLine(svg, tasks);
+    }
+
+    updateAddButton(tasks: ITask[]) {
+        const headerRow = document.getElementById('header-row');
+        const oldButton = document.getElementById('add-button');
+        headerRow.removeChild(oldButton);
+
+        const newButton = this.createButton(tasks);
+        headerRow.appendChild(newButton);
     }
 
     drawDependencyLine(svg: SVGElement, tasks: ITask[]) {

--- a/src/lib/Html/HtmlHelper.ts
+++ b/src/lib/Html/HtmlHelper.ts
@@ -58,7 +58,7 @@ class HtmlHelper{
 
 export function createElement(tag: string, className: string, content?: string , id?: string , type?: string): HTMLElement {
 	const el = document.createElement(tag);
-	if(className)
+	if (className) 
 	{
 		el.classList.add(className);
 	}

--- a/src/saveEdit.ts
+++ b/src/saveEdit.ts
@@ -282,11 +282,6 @@ export function deleteTask(tasks: ISubTask[] | ITask[], allTasks: ISubTask[] | I
         });
 
         tasks.splice(taskIndex, 1);
-
-        // Update the Gantt chart with the new data
-        updateTaskStartEndDates(tasks);
-
-        // Calling the function with sample data
         const chartData = allTasks || tasks;
         GanttChart.createChart(chartData);
     }

--- a/src/saveEdit.ts
+++ b/src/saveEdit.ts
@@ -84,8 +84,11 @@ export function addTask(tasks : ITask[] | ISubTask[]) {
         return;
     }
 
+    const existingIds = tasks.map((task: ITask | ISubTask) => task.id);
+    const newTaskId = Math.max(...existingIds, 0) + 1;
+
     const newTask:ITask|ISubTask = {
-        id: tasks.length + 1, // Incremental ID
+        id: newTaskId, // Incremental ID
         name: taskName,
         start: startDate,
         end: endDate,

--- a/src/saveEdit.ts
+++ b/src/saveEdit.ts
@@ -88,7 +88,7 @@ export function addTask(tasks : ITask[] | ISubTask[]) {
     const newTaskId = Math.max(...existingIds, 0) + 1;
 
     const newTask:ITask|ISubTask = {
-        id: newTaskId, // Incremental ID
+        id: newTaskId,
         name: taskName,
         start: startDate,
         end: endDate,


### PR DESCRIPTION
**Description of the problem this PR solves**
When deleting tasks and adding new ones, the IDs of new tasks were not unique, leading to redundancy.
Consecutive deletions caused the deleted tasks to still render in the chart when adding new tasks.

**Details of how the solution has been implemented**
Implemented a solution to ensure unique IDs for new tasks.
Updated the rendering of the add button to reflect the latest tasks in the chart.

**Testing instructions**
Delete at least two tasks from the chart.
Click the "Add Task" button to add a new task.
Verify that the previously deleted tasks are not rendered in the chart.
Confirm that the new task is added below the existing tasks.
Check the ID of the new task to ensure it is unique and does not match the IDs of other existing tasks.




